### PR TITLE
[17.0][FIX] hr_holidays: typo

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -549,7 +549,7 @@ class HrEmployee(models.Model):
                                 'leave_id': leave.id,
                             }
                     else:
-                        if leave_unit == 'hour':
+                        if leave_unit == 'hours':
                             allocated_time = leave.number_of_hours_display
                         else:
                             allocated_time = leave.number_of_days_display

--- a/doc/cla/individual/xaviedoanhduy.md
+++ b/doc/cla/individual/xaviedoanhduy.md
@@ -1,0 +1,11 @@
+Vietnam, 2024-08-22
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Do Anh Duy doanhduyxavie@gmail.com https://github.com/xaviedoanhduy


### PR DESCRIPTION
- During refactoring of hr_holidays for 17.0 (commit https://github.com/odoo/odoo/commit/8f87e102a95412aa7dd1b0ce07365d9d3bbdba6a) a typo was introduced.
- Because `leave_unit` is assigned `days` or `hours` according to [the condition](https://github.com/odoo/odoo/blob/1a58156cdd0cc9beefc472d1d2e481668d694f1e/addons/hr_holidays/models/hr_employee.py#L490), but when comparing the condition below `leave_unit == 'hour'`.