### PR TITLE
[17.0][IMP] hr_holidays_attendance: remove dead code

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_leave_type.py
+++ b/addons/hr_holidays_attendance/models/hr_leave_type.py
@@ -48,11 +48,6 @@ class HRLeaveType(models.Model):
                     leave_data[1]['overtime_deductible'] = False
         return res
 
-    def _get_days_request(self, date=None):
-        res = super()._get_days_request(date)
-        res[1]['overtime_deductible'] = self.overtime_deductible
-        return res
-
     @api.depends('company_id.hr_attendance_overtime')
     def _compute_hr_attendance_overtime(self):
         # If no company is linked to the time off type, use the current company's setting

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -159,7 +159,7 @@ class AccountEdiFormat(models.Model):
                 odoobot = self.env.ref("base.partner_root")
                 invoices.message_post(author_id=odoobot.id, body=
                     Markup("%s<br/>%s:<br/>%s") %(
-                        _("Somehow this E-waybill has been canceled in the government portal before. You can verify by checking the details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.asp)"),
+                        _("Somehow this E-waybill has been canceled in the government portal before. You can verify by checking the details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)"),
                         _("Error"),
                         error_message
                     )
@@ -226,7 +226,7 @@ class AccountEdiFormat(models.Model):
                     error = []
                     odoobot = self.env.ref("base.partner_root")
                     invoices.message_post(author_id=odoobot.id, body=
-                        _("Somehow this E-waybill has been generated in the government portal before. You can verify by checking the invoice details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.asp)")
+                        _("Somehow this E-waybill has been generated in the government portal before. You can verify by checking the invoice details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)")
                     )
 
             if "no-credit" in error_codes:
@@ -327,7 +327,7 @@ class AccountEdiFormat(models.Model):
                     error = []
                     odoobot = self.env.ref("base.partner_root")
                     invoices.message_post(author_id=odoobot.id, body=
-                        _("Somehow this E-waybill has been generated in the government portal before. You can verify by checking the invoice details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.asp)")
+                        _("Somehow this E-waybill has been generated in the government portal before. You can verify by checking the invoice details into the government (https://ewaybillgst.gov.in/Others/EBPrintnew.aspx)")
                     )
             if "no-credit" in error_codes:
                 res[invoices] = {

--- a/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
+++ b/addons/l10n_in_withholding/wizard/l10n_in_withhold_wizard.py
@@ -15,10 +15,10 @@ class L10nInWithholdWizard(models.TransientModel):
         result = super().default_get(fields_list)
         active_model = self._context.get('active_model')
         active_ids = self._context.get('active_ids')
-        if len(active_ids) > 1:
-            raise UserError(_("You can only create a withhold for only one record at a time."))
         if active_model not in ('account.move', 'account.payment') or not active_ids:
             raise UserError(_("TDS must be created from an Invoice or a Payment."))
+        if len(active_ids) > 1:
+            raise UserError(_("You can only create a withhold for only one record at a time."))
         active_record = self.env[active_model].browse(active_ids)
         result['reference'] = _("TDS of %s", active_record.name)
         if active_model == 'account.move':

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -405,7 +405,7 @@ class MailMail(models.Model):
         email_list = []
         if self.email_to:
             email_to_normalized = tools.email_normalize_all(self.email_to)
-            email_to = tools.email_split_and_format(self.email_to)
+            email_to = tools.email_split_and_format_normalize(self.email_to)
             email_list.append({
                 'email_cc': [],
                 'email_to': email_to,
@@ -419,11 +419,11 @@ class MailMail(models.Model):
         # with partner-specific sending)
         if self.email_cc:
             if email_list:
-                email_list[0]['email_cc'] = tools.email_split(self.email_cc)
+                email_list[0]['email_cc'] = tools.email_split_and_format_normalize(self.email_cc)
                 email_list[0]['email_to_normalized'] += tools.email_normalize_all(self.email_cc)
             else:
                 email_list.append({
-                    'email_cc':  tools.email_split(self.email_cc),
+                    'email_cc':  tools.email_split_and_format_normalize(self.email_cc),
                     'email_to': [],
                     'email_to_normalized': tools.email_normalize_all(self.email_cc),
                     'email_to_raw': False,
@@ -511,7 +511,7 @@ class MailMail(models.Model):
         group_per_email_from = defaultdict(list)
         for values in mail_values:
             # protect against ill-formatted email_from when formataddr was used on an already formatted email
-            emails_from = tools.email_split_and_format(values['email_from'])
+            emails_from = tools.email_split_and_format_normalize(values['email_from'])
             email_from = emails_from[0] if emails_from else values['email_from']
             mail_server_id = values['mail_server_id'][0] if values['mail_server_id'] else False
             alias_domain_id = values['record_alias_domain_id'][0] if values['record_alias_domain_id'] else False
@@ -632,7 +632,7 @@ class MailMail(models.Model):
                     notifs.flush_recordset(['notification_status', 'failure_type', 'failure_reason'])
 
                 # protect against ill-formatted email_from when formataddr was used on an already formatted email
-                emails_from = tools.email_split_and_format(mail.email_from)
+                emails_from = tools.email_split_and_format_normalize(mail.email_from)
                 email_from = emails_from[0] if emails_from else mail.email_from
 
                 # build an RFC2822 email.message.Message object and send it without queuing

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -403,6 +403,8 @@ export class Thread extends Component {
                 }),
                 this.props.thread
             );
+        } else {
+            this.store.handleClickOnLink(ev, this.props.thread);
         }
     }
 

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -73,6 +73,7 @@ export class ActivityController extends Component {
             title: _t("Search: %s", this.props.archInfo.title),
             multiSelect: false,
             context: this.props.context,
+            noCreate: this.props.context?.create === false,
             onSelected: async (resIds) => {
                 await this.activity.schedule(this.props.resModel, resIds);
             },

--- a/addons/mail/views/mail_mail_views.xml
+++ b/addons/mail/views/mail_mail_views.xml
@@ -46,9 +46,8 @@
                         </group>
                         <notebook>
                             <page string="Body" name="body">
-                            <field name="body_html" widget="html"
-                                   options="{'sandboxedPreview': true}"
-                                   readonly="state not in ['outgoing', 'exception']"/>
+                                <field name="body_content"/>
+                                <field name="body_html" invisible="1"/><!--to be removed-->
                             </page>
                             <page string="Advanced" name="advanced" groups="base.group_no_one">
                                 <group>

--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -8,12 +8,14 @@ class PosOrderLine(models.Model):
 
     def _get_stock_moves_to_consider(self, stock_moves, product):
         self.ensure_one()
-        bom = product.env['mrp.bom']._bom_find(product, company_id=stock_moves.company_id.id, bom_type='phantom')[product]
+        bom = product.env['mrp.bom']._bom_find(product, company_id=stock_moves.company_id.id, bom_type='phantom').get(product)
         if not bom:
             return super()._get_stock_moves_to_consider(stock_moves, product)
-        _dummy, components = bom.explode(product, self.qty)
+        boms, components = bom.explode(product, self.qty)
         ml_product_to_consider = (product.bom_ids and [comp[0].product_id.id for comp in components]) or [product.id]
-        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
+        if len(boms) > 1:
+            return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and ml.bom_line_id)
+        return stock_moves.filtered(lambda ml: ml.product_id.id in ml_product_to_consider and (ml.bom_line_id in bom.bom_line_ids))
 
 class PosOrder(models.Model):
     _inherit = "pos.order"

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -335,3 +335,116 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 6000.0)
         interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['stock_output'].id)
         self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 6000.0)
+
+    def test_bom_kit_order_total_cost_with_shared_component(self):
+        category = self.env['product.category'].create({
+            'name': 'Category for average cost',
+            'property_cost_method': 'average',
+        })
+
+        kit_1 = self.env['product.product'].create({
+            'name': 'Kit Product 1',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 30.0,
+            'categ_id': category.id,
+        })
+
+        kit_2 = self.env['product.product'].create({
+            'name': 'Kit Product 2',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 200.0,
+            'categ_id': category.id,
+        })
+
+        shared_component_a = self.env['product.product'].create({
+            'name': 'Shared Comp A',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 10.0,
+            'standard_price': 5.0,
+
+        })
+
+        other_component_a = self.env['product.product'].create({
+            'name': 'Other Comp A',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 20.0,
+            'standard_price': 10.0,
+        })
+
+        other_component_b = self.env['product.product'].create({
+            'name': 'Other Comp B',
+            'type': 'product',
+            'available_in_pos': True,
+            'lst_price': 30.0,
+            'standard_price': 20.0,
+        })
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_1
+        bom_product_form.product_tmpl_id = kit_1.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 1.0
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = other_component_a
+            bom_line.product_qty = 1.0
+        self.bom_a = bom_product_form.save()
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = kit_2
+        bom_product_form.product_tmpl_id = kit_2.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = shared_component_a
+            bom_line.product_qty = 10.0
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = other_component_b
+            bom_line.product_qty = 5.0
+        self.bom_b = bom_product_form.save()
+
+        self.pos_config.open_ui()
+        order = self.env['pos.order'].create({
+            'session_id': self.pos_config.current_session_id.id,
+            'lines': [(0, 0, {
+                'name': kit_1.name,
+                'product_id': kit_1.id,
+                'price_unit': kit_1.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_1.lst_price,
+                'price_subtotal_incl': kit_1.lst_price,
+            }), (0, 0, {
+                'name': kit_2.name,
+                'product_id': kit_2.id,
+                'price_unit': kit_2.lst_price,
+                'qty': 1,
+                'tax_ids': [[6, False, []]],
+                'price_subtotal': kit_2.lst_price,
+                'price_subtotal_incl': kit_2.lst_price,
+            })],
+            'pricelist_id': self.pos_config.pricelist_id.id,
+            'amount_paid': kit_1.lst_price + kit_2.lst_price,
+            'amount_total': kit_1.lst_price + kit_2.lst_price,
+            'amount_tax': 0.0,
+            'amount_return': 0.0,
+            'to_invoice': False,
+        })
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.PosMakePayment.with_context(**payment_context).create({
+            'amount': order.amount_total,
+            'payment_method_id': self.cash_payment_method.id
+        })
+        order_payment.with_context(**payment_context).check()
+        self.pos_config.current_session_id.action_pos_session_closing_control()
+        pos_order = self.env['pos.order'].search([], order='id desc', limit=1)
+        self.assertRecordValues(pos_order.lines, [
+            {'product_id': kit_1.id, 'total_cost': 15.0},
+            {'product_id': kit_2.id, 'total_cost': 150.0},
+        ])

--- a/addons/pos_restaurant_loyalty/__init__.py
+++ b/addons/pos_restaurant_loyalty/__init__.py
@@ -1,0 +1,1 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.

--- a/addons/pos_restaurant_loyalty/__manifest__.py
+++ b/addons/pos_restaurant_loyalty/__manifest__.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': 'POS - Restaurant Loyality',
+    'version': '1.0',
+    'category': 'Hidden',
+    'sequence': 6,
+    'summary': 'Link module between pos_restaurant and pos_loyalty',
+    'description': """
+This module correct some behaviors when both module are installed.
+""",
+    'depends': ['pos_restaurant', 'pos_loyalty'],
+    'installable': True,
+    'auto_install': True,
+    'assets': {
+        'point_of_sale._assets_pos': [
+            'pos_restaurant_loyalty/static/src/**/*',
+        ],
+        'web.assets_tests': [
+            'pos_restaurant_loyalty/static/tests/tours/**/*',
+        ],
+    },
+    'license': 'LGPL-3',
+}

--- a/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant_loyalty/static/src/overrides/models/pos_store.js
@@ -1,0 +1,11 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+
+patch(PosStore.prototype, {
+    async setTable(table, orderUid = null) {
+        await super.setTable(...arguments)
+        this.selectedOrder._updateRewards()
+    }
+})

--- a/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
+++ b/addons/pos_restaurant_loyalty/static/tests/tours/PosRestaurantLoyaltyTour.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import * as ProductScreen from "@point_of_sale/../tests/tours/helpers/ProductScreenTourMethods";
+import * as FloorScreen from "@pos_restaurant/../tests/tours/helpers/FloorScreenTourMethods";
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("PosRestaurantRewardStay", {
+    test: true,
+    steps: () =>
+        [
+            ProductScreen.confirmOpeningPopup(),
+            FloorScreen.clickTable("5"),
+
+            ProductScreen.clickHomeCategory(),
+            ProductScreen.clickDisplayedProduct("Water"),
+            ProductScreen.totalAmountIs("1.98"),
+            FloorScreen.backToFloor(),
+            FloorScreen.clickTable("5"),
+            ProductScreen.totalAmountIs("1.98"),
+        ].flat()
+})

--- a/addons/pos_restaurant_loyalty/tests/__init__.py
+++ b/addons/pos_restaurant_loyalty/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_pos_restaurant_loyalty

--- a/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
+++ b/addons/pos_restaurant_loyalty/tests/test_pos_restaurant_loyalty.py
@@ -1,0 +1,36 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.pos_restaurant.tests.test_frontend import TestFrontend
+from odoo.tests import tagged
+from odoo import Command
+
+
+@tagged("post_install", "-at_install")
+class TestPoSRestaurantLoyalty(TestFrontend):
+    def test_change_table_rewards_stay(self):
+        """
+        Test that make sure that rewards stay on the order when leaving the table
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env['loyalty.program'].create({
+            'name': 'My super program',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'minimum_qty': 1,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 10,
+                'discount_mode': 'percent',
+                'discount_applicability': 'order',
+            })],
+            'pos_config_ids': [Command.link(self.pos_config.id)],
+        })
+        self.pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.pos_config.id,
+            "PosRestaurantRewardStay",
+            login="pos_admin",
+        )

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -716,3 +716,64 @@ class TestRepair(common.TransactionCase):
         self.assertEqual(len(res), 1, "The invoice should have one line")
         self.assertEqual(res[0]['product_name'], self.product_storable_serial.display_name, "The product name should be the same")
         self.assertEqual(res[0]['lot_name'], quant.lot_id.name, "The lot name should be the same")
+
+    def test_trigger_orderpoint_from_repair(self):
+        """
+        Test that the order point triggered by the repair order creates a move linked to a picking.
+        """
+        self.assertFalse(self.env['stock.move'].search([('product_id', '=', self.product_storable_no.id)]))
+        route = self.env['stock.route'].create({
+            'name': 'new route',
+            'rule_ids': [(0, False, {
+                'name': 'rule_test',
+                'location_src_id': self.stock_warehouse.lot_stock_id.id,
+                'location_dest_id': self.stock_location_14.id,
+                'company_id': self.env.company.id,
+                'action': 'pull',
+                'picking_type_id': self.env.ref('stock.picking_type_in').id,
+                'procure_method': 'make_to_stock'
+            })],
+        })
+        self.env['stock.warehouse.orderpoint'].create({
+            'name': 'Cake RR',
+            'product_id': self.product_storable_no,
+            'route_id': route.id,
+            'location_id': self.stock_location_14.id,
+            'product_id': self.product_storable_no.id,
+            'product_min_qty': 0,
+            'product_max_qty': 1,
+            'trigger': 'auto'
+        })
+        # The product to be repaired should be storable and out of stock
+        # to trigger the wizard indicating that the product has an insufficient quantity.
+        self.product_product_3.type = 'product'
+        repair_order = self.env['repair.order'].create({
+            'product_id': self.product_product_3.id,
+            'product_uom': self.product_product_3.uom_id.id,
+            'partner_id': self.res_partner_12.id,
+            'location_id': self.stock_location_14.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.product_storable_no.id,
+                    'product_uom_qty': 1.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                })
+            ],
+        })
+        validate_action = repair_order.action_validate()
+        self.assertEqual(validate_action.get("res_model"), "stock.warn.insufficient.qty.repair")
+        warn_qty_wizard = Form(
+            self.env['stock.warn.insufficient.qty.repair']
+            .with_context(**validate_action['context'])
+            ).save()
+        warn_qty_wizard.action_done()
+        self.assertEqual(repair_order.state, "confirmed", 'Repair order should be in "Confirmed" state.')
+        move = self.env['stock.move'].search([
+            ('product_id', '=', self.product_storable_no.id),
+            ('location_dest_id', '=', self.stock_location_14.id,)
+        ])
+        self.assertTrue(move.picking_id)
+        self.assertFalse(move.repair_id)
+        self.assertEqual(move.location_id, self.stock_warehouse.lot_stock_id)
+        self.assertEqual(move.location_dest_id, self.stock_location_14)

--- a/addons/repair/wizard/stock_warn_insufficient_qty.py
+++ b/addons/repair/wizard/stock_warn_insufficient_qty.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
+from odoo.tools.misc import clean_context
 
 
 class StockWarnInsufficientQtyRepair(models.TransientModel):
@@ -16,4 +17,5 @@ class StockWarnInsufficientQtyRepair(models.TransientModel):
 
     def action_done(self):
         self.ensure_one()
+        self = self.with_context(clean_context(self.env.context))
         return self.repair_id._action_repair_confirm()

--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -59,7 +59,7 @@ class SnailmailLetter(models.Model):
              "If the letter is correctly sent, the status goes in 'Sent',\n"
              "If not, it will got in state 'Error' and the error message will be displayed in the field 'Error Message'.")
     error_code = fields.Selection([(err_code, err_code) for err_code in ERROR_CODES], string="Error")
-    info_msg = fields.Char('Information')
+    info_msg = fields.Html('Information')
 
     reference = fields.Char(string='Related Record', compute='_compute_reference', readonly=True, store=False)
 

--- a/addons/test_mail/static/tests/activity_tests.js
+++ b/addons/test_mail/static/tests/activity_tests.js
@@ -1495,4 +1495,30 @@ QUnit.module("test_mail", {}, function () {
         await click(target, ".modal-footer button.o_form_button_cancel");
         assert.containsOnce(target, ".o_activity_summary_cell:not(.o_activity_empty_cell)");
     });
+
+    QUnit.test(
+        "Activity View: Hide 'New' button in SelectCreateDialog based on action context",
+        async function (assert) {
+            assert.expect(1);
+
+            Object.assign(serverData.views, {
+                "mail.test.activity,false,list":
+                    '<tree string="MailTestActivity"><field name="name"/></tree>',
+            });
+
+            const { openView } = await start({
+                serverData,
+            });
+            await openView({
+                res_model: "mail.test.activity",
+                views: [[false, "activity"]],
+                context: { create: false },
+            });
+
+            const activity = $(document);
+            await testUtils.dom.click(activity.find("table tfoot tr .o_record_selector"));
+
+            assert.containsNone(activity, ".o_create_button", "'New' button should be hidden.");
+        }
+    );
 });

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -1854,7 +1854,10 @@ class TestMailgateway(MailCommon):
 
         self.assertEqual(set(records.mapped('email_from')), {self.email_from})
 
-        for email_from in (self.email_from, self.email_from.upper()):
+        for email_from, exp_to in [
+            (self.email_from, formataddr(("Sylvie Lelitre", "test.sylvie.lelitre@agrolait.com"))),
+            (self.email_from.upper(), formataddr(("SYLVIE LELITRE", "test.sylvie.lelitre@agrolait.com"))),
+        ]:
             with self.mock_mail_gateway():
                 self.format_and_process(
                     MAIL_TEMPLATE,
@@ -1870,7 +1873,7 @@ class TestMailgateway(MailCommon):
                 new_record,
                 msg='The loop should have been detected and the record should not have been created')
 
-            self.assertSentEmail(f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>', [email_from])
+            self.assertSentEmail(f'"MAILER-DAEMON" <{self.alias_bounce}@{self.alias_domain}>', [exp_to])
             self.assertIn('-loop-detection-bounce-email@', self._mails[0]['references'],
                 msg='The "bounce email" tag must be in the reference')
 

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -306,8 +306,8 @@ export class Link extends Component {
         var doStripDomain = this._doStripDomain();
         if (this.state.url.indexOf(location.origin) === 0 && doStripDomain) {
             this.state.url = this.state.url.slice(location.origin.length);
-        } else {
-            this.state.url = url
+        } else if (url.indexOf(location.origin) === 0 && !doStripDomain) {
+            this.state.url = url;
         }
         var allWhitespace = /\s+/gi;
         var allStartAndEndSpace = /^\s+|\s+$/gi;

--- a/doc/cla/corporate/vauxoo.md
+++ b/doc/cla/corporate/vauxoo.md
@@ -74,3 +74,4 @@ German Loredo german@vauxoo.com https://github.com/xmglord
 Antonio Aguilar antonio@vauxoo.com https://github.com/antonag32
 Christihan Laurel laurel@vauxoo.com https://github.com/CLaurelB
 Andrea Manenti manenti@vauxoo.com https://github.com/maneandrea
+Eduardo Martinez eduardoms@vauxoo.com https://github.com/emtz10

--- a/odoo/addons/base/tests/test_res_currency.py
+++ b/odoo/addons/base/tests/test_res_currency.py
@@ -101,3 +101,20 @@ class TestResCurrency(TransactionCase):
                 company=self.env.company,
                 date='2011-11-11',
             ), 200)
+
+    def test_res_currency_name_search(self):
+        currency_A, currency_B = self.env["res.currency"].create([
+            {"name": "cuA", "symbol": "A"},
+            {"name": "cuB", "symbol": "B"},
+        ])
+        self.env["res.currency.rate"].create([
+            {"name": "1971-01-01", "rate": 2.0, "currency_id": currency_A.id},
+            {"name": "1971-01-01", "rate": 1.5, "currency_id": currency_B.id},
+            {"name": "1972-01-01", "rate": 0.69, "currency_id": currency_B.id},
+        ])
+        # should not try to match field 'rate' (float field)
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "1971-01-01"]]), 2)
+        # should not try to match field 'name' (date field)
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "0.69"]]), 1)
+        # should not try to match any of 'name' and 'rate'
+        self.assertEqual(self.env["res.currency"].search_count([["rate_ids", "=", "irrelevant"]]), 0)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -615,6 +615,14 @@ def email_split_and_format(text):
         return []
     return [formataddr((name, email)) for (name, email) in email_split_tuples(text)]
 
+def email_split_and_format_normalize(text):
+    """ Same as 'email_split_and_format' but normalizing email. """
+    return [
+        formataddr(
+            (name, _normalize_email(email))
+        ) for (name, email) in email_split_tuples(text)
+    ]
+
 def email_normalize(text, strict=True):
     """ Sanitize and standardize email address entries. As of rfc5322 section
     3.4.1 local-part is case-sensitive. However most main providers do consider


### PR DESCRIPTION
during refactoring of `hr_holidays` for 17.0 (commit https://github.com/odoo/odoo/commit/8f87e102a95412aa7dd1b0ce07365d9d3bbdba6a), the `_get_days_request` function has been removed in the `hr_holidays` module, but it is still overridden in `hr_holidays_attendance`