### PR TITLE
[15.0][FIX] stock: fix Traceability Report layout

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -98,9 +98,8 @@
             'stock/static/src/scss/report_stock_forecasted.scss',
             'stock/static/src/scss/report_stock_reception.scss',
             'stock/static/src/scss/report_stock_rule.scss',
-        ],
-        'web.assets_common': [
             'stock/static/src/scss/stock_traceability_report.scss',
+
         ],
         'web.assets_backend': [
             'stock/static/src/js/inventory_report_list_controller.js',

--- a/addons/stock/views/report_stock_traceability.xml
+++ b/addons/stock/views/report_stock_traceability.xml
@@ -74,15 +74,15 @@
             </div>
         </div>
     </template>
-
+    
+    <template id="layout" name="Report Layout" inherit_id="web.report_layout">
+        <xpath expr="//head/meta[1]" position="before">
+            <base t-att-href="base_url"/>
+        </xpath>
+    </template>
+    
     <template id="report_stock_inventory_print">
         <t t-call="web.html_container">
-            <t t-set="head_start">
-                <base t-att-href="base_url"/>
-            </t>
-            <t t-set="head_end">
-                <t t-call-assets="stock.assets_stock_print_report" t-js="False"/>
-            </t>
             <t t-call='stock.report_stock_body_print'/>
         </t>
     </template>

--- a/doc/cla/individual/xaviedoanhduy.md
+++ b/doc/cla/individual/xaviedoanhduy.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-01-7
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Do Anh Duy doanhduyxavie@gmail.com https://github.com/xaviedoanhduy


### PR DESCRIPTION
Description of the issue/feature this PR addresses: during the process of "declare assets in manifest, not in xml" (in commit https://github.com/odoo/odoo/pull/60632/commits/03641610c), the `assets_stock_print_report` template to declare assets was deleted and replaced with `web.assets_common` in key `assets` of `__manifest__.py`, but the value of `t-call-assets` was not updated, so this asset was not loaded in the Traceability Report.

Current behavior before PR: the report interface is broken as below, due to not loading the required assets correctly
[stock_traceability.pdf](https://github.com/user-attachments/files/18281023/version-15.0.pdf)


Desired behavior after PR is merged: re-introduce assets `assets_stock_print_report`, so that the report can load this asset correctly generate the report as desired.
[stock_traceability.pdf](https://github.com/user-attachments/files/18281024/stock_traceability.6.pdf)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
