### PR TITLE
[15.0][FIX] mrp: BOM Structure & Cost

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -288,7 +288,7 @@
     <template id="report_bom_structure">
         <t t-set="data_report_landscape" t-value="True"/>
         <t t-call="web.basic_layout">
-            <t t-call-assets="mrp.assets_common" t-js="False"/>
+            <t t-call-assets="web.assets_common" t-js="False"/>
             <t t-foreach="docs" t-as="data">
                 <div class="page">
                     <t t-call="mrp.report_mrp_bom"/>

--- a/doc/cla/individual/xaviedoanhduy.md
+++ b/doc/cla/individual/xaviedoanhduy.md
@@ -1,0 +1,11 @@
+Vietnam, 2025-01-7
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Do Anh Duy doanhduyxavie@gmail.com https://github.com/xaviedoanhduy


### PR DESCRIPTION
Description of the issue/feature this PR addresses: `mrp.assets_common` assets are obsolete as the assets are no longer declared in the `xml` files from commit https://github.com/odoo/odoo/commit/03641610c, so when calling `mrp.assets_common` the assets in `web.assets_common` are never called correctly, causing the report to be missing the `.css` resources in that asset.

Current behavior before PR: 
[BoM Structure (7).pdf](https://github.com/user-attachments/files/18327545/BoM.Structure.7.pdf)


Desired behavior after PR is merged: 
[BoM Structure (8).pdf](https://github.com/user-attachments/files/18327547/BoM.Structure.8.pdf)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
