### PR TITLE
[18.0][FIX] base: update _xmlid_lookup docstring to reflect correct return values

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2228,7 +2228,7 @@ class IrModelData(models.Model):
     @tools.ormcache('xmlid')
     def _xmlid_lookup(self, xmlid: str) -> tuple:
         """Low level xmlid lookup
-        Return (id, res_model, res_id) or raise ValueError if not found
+        Return (res_model, res_id) or raise ValueError if not found
         """
         module, name = xmlid.split('.', 1)
         query = "SELECT model, res_id FROM ir_model_data WHERE module=%s AND name=%s"


### PR DESCRIPTION
Description of the issue/feature this PR addresses: from [this commit](https://github.com/odoo/odoo/pull/129029/commits/4a070832), the docstring of `_xmlid_lookup` incorrectly states that the method returns `(id, res_model, res_id)`, while in reality, it only returns `(res_model, res_id)`.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
