### PR TITLE
[FIX] core: robust timezone handling for legacy aliases (e.g. Asia/Saigon)

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -2039,7 +2039,7 @@ class BaseModel(metaclass=MetaModel):
         field_type = field.type
         gb_function = split[1] if len(split) == 2 else None
         temporal = field_type in ('date', 'datetime')
-        tz_convert = field_type == 'datetime' and self._context.get('tz') in pytz.all_timezones
+        tz_convert = field_type == 'datetime' and pytz.timezone(self._context.get('tz'))
         qualified_field = self._inherits_join_calc(self._table, split[0], query)
         if temporal:
             display_formats = {
@@ -2068,7 +2068,7 @@ class BaseModel(metaclass=MetaModel):
                 'year': dateutil.relativedelta.relativedelta(years=1)
             }
             if tz_convert:
-                qualified_field = "timezone('%s', timezone('UTC',%s))" % (self._context.get('tz', 'UTC'), qualified_field)
+                qualified_field = "timezone('%s', timezone('UTC',%s))" % (pytz.timezone(self._context.get('tz', 'UTC')), qualified_field)
             qualified_field = "date_trunc('%s', %s::timestamp)" % (gb_function or 'month', qualified_field)
         if field_type == 'boolean':
             qualified_field = "coalesce(%s,false)" % qualified_field

--- a/odoo/tools/_monkeypatches_pytz.py
+++ b/odoo/tools/_monkeypatches_pytz.py
@@ -124,7 +124,8 @@ original_pytz_timezone = pytz.timezone
 
 
 def timezone(name):
-    if name not in pytz.all_timezones_set and name in _tz_mapping:
+    # Prioritize mapping if present in _tz_mapping
+    if name in _tz_mapping:
         name = _tz_mapping[name]
     return original_pytz_timezone(name)
 


### PR DESCRIPTION
On some environments (notably Ubuntu **24.04** / Noble and later), when users configure their timezone as `Asia/Saigon`, `read_group` on datetime fields crashes with: `psycopg2.errors.InvalidParameterValue: time zone "Asia/Saigon" not recognized`

**Steps to reproduce:**
1. Install Odoo `16.0` on Ubuntu 24.04.
2. Set user timezone to Asia/Saigon.
3. Open a menu view (e.g., Helpdesk).
4. Odoo triggers a grouped query with SQL like:
5. `SELECT date_trunc('day', timezone('Asia/Saigon', timezone('UTC', t.close_date))) AS ...`
6. PostgreSQL fails because `Asia/Saigon` is no longer present in system zoneinfo.

**Technical cause:**

- `pytz.all_timezones_set` still contains legacy aliases (e.g. Asia/Saigon), so Odoo assumes them valid.
- At SQL generation time (`_read_group_process_groupby`), Odoo injects them directly.
- However, PostgreSQL relies on the system tzdata, which no longer includes some legacy names.
- Result: Odoo accepts the tz string, but Postgres rejects it at runtime.

**Fix:**
This patch makes two changes:

- In `_read_group_process_groupby`, validate the `tz` string with `pytz.timezone(...)` instead of a simple membership check This ensures only resolvable zones are passed.
- In `_monkeypatches_pytz`, always apply `_tz_mapping` (e.g. Asia/Saigon → Asia/Ho_Chi_Minh) even if the alias is still present in `pytz`. This guarantees consistent canonical usage.

**Result:**

- Prevents runtime crashes in reports and dashboards.
- Ensures legacy aliases transparently map to canonical names.
