### PR TITLE
[FIX] base: prevent crash on uninstall when checking undeletable module data

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -2318,6 +2318,10 @@ class IrModelData(models.Model):
         # of records being cascade-deleted or tables being dropped just above
         for data in self.browse(undeletable_ids).exists():
             record = self.env[data.model].browse(data.res_id)
+            table_name = record._table
+            if not tools.table_exists(self._cr, table_name):
+                _logger.debug("Skipping record %s because table %s does not exist", data, table_name)
+                continue
             try:
                 with self.env.cr.savepoint():
                     if record.exists():


### PR DESCRIPTION
PR `https://github.com/odoo/odoo/pull/72802` introduced an additional `record.exists()` check to revalidate xmlids that were previously undeletable, in case they became deletable after a model or field was dropped. This prevents orphaned `ir.model.data`.

However, calling `.exists()` on a record whose underlying table has  already been dropped raises some Errors.

Steps to reproduce:
-------------------

1. Install a module such as `account`.
2. Create some records (e.g. customer invoice).
3. Uninstall the module.
4. During uninstallation, the sanity check queries `record.exists()` for `ir.model.data` entries pointing to models whose tables have already been dropped.
7. This causes a crash:
```
2025-09-24 11:32:50,424 486370 ERROR v16e_account odoo.sql_db: bad query:
SELECT "account_account_tag".id FROM "account_account_tag" WHERE "account_account_tag".id IN (1)
ERROR: relation "account_account_tag" does not exist
LINE 1: SELECT "account_account_tag".id FROM "account_account_tag" W...
```


Fix:
----
Before calling `record.exists()`, we now ensure that the underlying table still exists (via `tools.table_exists()`). If the table is missing, the record is considered deleted and its `ir.model.data` entry is cleaned up.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
