### PR TITLE
[FIX] hr_holidays: remove dead code request_unit_custom key

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -82,7 +82,6 @@ class HolidaysRequest(models.Model):
             lt = self.env['hr.leave.type'].search(['|', ('requires_allocation', '=', 'no'), ('has_valid_allocation', '=', True)], limit=1, order='sequence')
             if lt:
                 defaults['holiday_status_id'] = lt.id
-                defaults['request_unit_custom'] = False
 
         if 'request_date_from' in fields_list and 'request_date_from' not in defaults:
             defaults['request_date_from'] = fields.Date.today()


### PR DESCRIPTION
the `request_unit_custom` field was removed in `https://github.com/odoo/odoo/pull/77036`, but the changes in that PR accidentally did not fully clean up all references and logic related to `request_unit_custom`