### PR TITLE
[FIX] stock: Remove duplicated packaging display logic in picking report

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -122,10 +122,7 @@
                                             <span t-field="ml.quantity" class="text-nowrap">3.00</span>
                                             <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
                                             <span t-if="ml.move_id.product_packaging_id">
-                                                <span t-if="o.state != 'done'">
-                                                    (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
-                                                </span>
-                                                <span t-if="o.state == 'done'">
+                                                <span>
                                                     (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
                                                 </span>
                                             </span>


### PR DESCRIPTION
This change removes duplicated QWeb logic where two identical conditional blocks were used for different picking states.
The output remains unchanged, but the template is now simpler, clearer, and easier to read.