### PR TITLE
[FIX] stock: rename group-by filter 'origin' to 'groupby_origin' in picking search view

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -412,7 +412,7 @@
                     <group expand="0" string="Group By">
                         <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                         <filter string="Scheduled Date" name="expected_date" domain="[]" context="{'group_by': 'scheduled_date'}"/>
-                        <filter string="Source Document" name="origin" domain="[]" context="{'group_by': 'origin'}"/>
+                        <filter string="Source Document" name="groupby_origin" domain="[]" context="{'group_by': 'origin'}"/>
                         <filter string="Operation Type" name="picking_type" domain="[]" context="{'group_by': 'picking_type_id'}"/>
                     </group>
                 </search>


### PR DESCRIPTION
## Problem

In `view_picking_internal_search`, the group-by filter for "Source Document" and the search `<field>` both use `name="origin"`:

```xml
<field name="origin"/>
...
<filter string="Source Document" name="origin" domain="[]" context="{'group_by': 'origin'}"/>
```

When an action sets `search_default_origin=1` in its context, Odoo activates **both** elements simultaneously — the field search (with the literal value `"1"`) and the group-by filter — causing two "Source Document" tags to appear in the search bar.

## Fix

Rename the group-by filter from `name="origin"` to `name="groupby_origin"`, following the convention already used in the codebase (e.g. `groupby_partner`, `groupby_state`). The `context="{'group_by': 'origin'}"` attribute is unchanged, so the grouping behavior is preserved.

Actions that want to activate only the group-by can now use `search_default_groupby_origin=1` without side effects on the field search.

<img width="1855" height="929" alt="image" src="https://github.com/user-attachments/assets/22b37080-181d-4712-84ef-f7ea18bf825d" />
