### PR TITLE
[FIX] mrp: sync work order date readonly with the form view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -78,8 +78,8 @@
                 <field name="qty_remaining" optional="show" string="Quantity"/>
                 <field name="qty_ready" optional="hide" groups="base.group_no_one"/>
                 <field name="finished_lot_ids" optional="hide" string="Lot/Serial"/>
-                <field name="date_start" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
-                <field name="date_finished" optional="hide" readonly="state in ['progress', 'done', 'cancel']"/>
+                <field name="date_start" optional="hide" readonly="state in ['cancel', 'done']"/>
+                <field name="date_finished" optional="hide" readonly="state in ['cancel', 'done']"/>
                 <field name="duration_expected" widget="float_time" sum="expected duration" readonly="state in ['cancel', 'done']"/>
                 <field name="duration" widget="mrp_timer"
                   invisible="production_state == 'draft'"


### PR DESCRIPTION
## Problem

in the manufacturing order form, the embedded work order **list** keeps `date_start` / `date_finished` readonly when the work order is in `progress`, while the work order **form** (opened as a dialog from that same list) lets them be edited in `progress` (readonly only for `cancel` / `done`).

because of this mismatch, a user can open the dialog, change the dates and save: the new value shows in the list until the page is reloaded, then it **silently reverts** to the old value. The readonly field is stripped from the RPC payload on save, so the change never reaches the server and no error is raised — a silent data loss.

## Root cause

- d4ed9f8a50fb introduced the `['progress', 'done', 'cancel']` readonly on both the list and the form.
- 67c29f21465a  **deliberately** made the form dates editable in `progress` (dropping the former "Scheduled Date" / "Start Date" label split), setting `readonly="state in ['cancel', 'done']"`. It did **not** update the embedded list, which was left at the older `['progress', 'done', 'cancel']`.

## Fix

Align the list with the form: dates editable in `progress`, readonly only for `cancel` / `done`. This is a sync to the intent already chosen in `67c29f21465a`, not a behavior change.

## Reproduce

1. open a confirmed/in-progress MO with a planned work order in state `progress`.
2. in the Work Orders tab, open the work order row (dialog).
3. change the Start Date or End Date, save the wizard  — the new date shows in the list.

<img width="1854" height="1010" alt="image" src="https://github.com/user-attachments/assets/95ad1946-e4ff-4152-9b1e-cc36b31d9fb5" />


<img width="1856" height="1013" alt="image" src="https://github.com/user-attachments/assets/9c7d5e96-b509-4320-a45d-93d158cc3f04" />

4. save MO → the date reverts to the old value (change lost, no error).

<img width="1856" height="1010" alt="image" src="https://github.com/user-attachments/assets/12805e86-8da2-4d86-a71e-9d0e237cd66f" />


